### PR TITLE
🖌 FRONTEND - copy pre-code on Doc page

### DIFF
--- a/src/components/Doc.jsx
+++ b/src/components/Doc.jsx
@@ -1,5 +1,7 @@
+import PreCode from './PreCode.jsx'
+
 function Doc() {
-  let texto1 = String.raw`
+  const texto1 = String.raw`
   {
     "categories": [
       {
@@ -17,7 +19,8 @@ function Doc() {
     ]
   }
     `;
-  let texto2 = String.raw`
+
+  const texto2 = String.raw`
   [
     {
       "id": "75",
@@ -85,7 +88,7 @@ function Doc() {
   return (
     <>
       <div className="min-h-[calc(100vh-121px)] container mx-auto justify-start p-4">
-        <div class="flex flex-col pt-12 gap-6">
+        <div className="flex flex-col pt-12 gap-6">
           <h1 className="mb-10 text-3xl">
             <b>Documentación</b>
           </h1>
@@ -152,18 +155,9 @@ function Doc() {
               disponibles.
             </p>
             <br />
-            <div class="mockup-code">
-              <pre data-prefix="$">
-                <code>{"https://www.preguntapi.dev/api/v1/categories"}</code>
-              </pre>
-            </div>
+            <PreCode code="https://www.preguntapi.dev/api/v1/categories" />
             <br />
-            <div class="mockup-code">
-              <pre data-prefix="$">
-                <code>{texto1}</code>
-              </pre>
-            </div>
-
+            <PreCode code={texto1} />
             <br />
             <p>
               El único recurso disponible es "quizzes", se utiliza para obtener
@@ -180,21 +174,9 @@ function Doc() {
             <p className="text-xl mb-4 mt-4">
               <b>Ejemplo:</b>
             </p>
-            <div class="mockup-code">
-              <pre data-prefix="$">
-                <code>
-                  {
-                    "https://www.preguntapi.dev/api/v1/quizzes?category=javascript&limit=5&level=facil"
-                  }
-                </code>
-              </pre>
-            </div>
+            <PreCode code="https://www.preguntapi.dev/api/v1/quizzes?category=javascript&limit=5&level=facil" />
             <br />
-            <div class="mockup-code">
-              <pre data-prefix="$">
-                <code>{texto2}</code>
-              </pre>
-            </div>
+            <PreCode code={texto2} />
             <br />
             <h2 className="text-2xl">
               <b>GraphQL</b>
@@ -204,11 +186,7 @@ function Doc() {
               no dudes en probarlo.
             </p>
             <br />
-            <div class="mockup-code">
-              <pre data-prefix="$">
-                <code>{"https://www.preguntapi.dev/graphql"}</code>
-              </pre>
-            </div>
+            <PreCode code="https://www.preguntapi.dev/graphql" />
           </div>
         </div>
       </div>

--- a/src/components/PreCode.jsx
+++ b/src/components/PreCode.jsx
@@ -1,0 +1,18 @@
+import IconCopy from './icons/IconCopy'
+
+const PreCode = ({ code = "", prefix = "$" }) => {
+  const clickOnCopy = () => {
+    navigator.clipboard.writeText(code)
+  }
+
+  return (
+    <div className="mockup-code">
+      <p className='absolute right-3 top-4 cursor-pointer' onClick={clickOnCopy}><IconCopy /></p>
+      <pre data-prefix={prefix}>
+        <code>{code}</code>
+      </pre>
+    </div>
+  )
+}
+
+export default PreCode

--- a/src/components/icons/IconCopy.jsx
+++ b/src/components/icons/IconCopy.jsx
@@ -1,0 +1,18 @@
+export default () => {
+	return (
+		<svg
+			className='w-6 h-6 mx-2'
+			fill='none'
+			stroke='currentColor'
+			viewBox='0 0 24 24'
+			xmlns='http://www.w3.org/2000/svg'
+		>
+			<path
+				strokeLinecap='round'
+				strokeLinejoin='round'
+				strokeWidth='2'
+				d='M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z'
+			></path>
+		</svg>
+	)
+}


### PR DESCRIPTION
Buen día!

- Se crea componente personalizado para el renderizado de secciones de texto (código) sobre etiqueta `<pre>`
- Se crea carpeta y componente IconCopy para renderizado de iconos SVG
- Se añade funcionalidad para copiar texto de `<pre>` en el cortapapeles del usuario